### PR TITLE
✨ [STEP12] Redis 기반 캐싱 전략 및 적용, 캐싱 전략 및 성능 보고서 작성

### DIFF
--- a/docs/report/03.CacheStrategyArchitectureReport.md
+++ b/docs/report/03.CacheStrategyArchitectureReport.md
@@ -1,0 +1,359 @@
+# 캐시 전략 설계
+
+## 🖼️ 배경
+
+조회 시간이 오래 걸리거나, 요청 빈도가 높거나, 자주 변하지 않는 데이터를 대상으로 캐시를 적용하면 시스템 성능을 효율적으로 개선할 수 있다.
+
+이번 전략에서는 전체 조회 기능 중 캐시가 효과적으로 작동할 수 있는 대상을 선별하고, 각 기능에 맞는 캐시 전략을 수립한다.   
+TTL(Time-To-Live), Eviction 정책, Warm-up 등 다양한 요소를 고려해 캐시의 **적중률(Hit Rate)을** 높이고 **미스(Miss)를** 줄이는 것이
+목적이다.
+
+단, 캐시는 성능 향상에 유리한 도구이지만, 데이터 정합성이 중요한 기능에서는 성능보다 정확성이 우선되어야 한다.   
+따라서 단순히 모든 조회에 일괄 적용하기보다, 기능 특성에 따라 정합성과 성능의 균형을 고려한 설계가 필요하다.
+
+## 🗳️ 캐싱 대상 선정
+
+### ⭐️ 인기 상품 조회
+
+**인기 상품 조회**는 요청 빈도가 높고, 하루 동안 데이터가 변경되지 않는 특성상 캐시 적용에 매우 적합한 기능이다.   
+조회 수요는 높지만 변경 빈도는 낮기 때문에, 캐시를 통해 성능과 트래픽 처리 효율을 동시에 개선할 수 있다.
+
+> 향후 기능이 확장되면, **상품 상세 조회(PDP)**와 같은 기능에도 캐시 적용을 고려할 수 있다.  
+> 또한 MSA 환경에서는 BFF(Backend for Frontend) 계층에서 **멀티 캐시 레이어**를 구성하여 API 응답 캐싱을 최적화할 수 있다.
+
+## ✨ 캐싱 전략 - 인기 상품 조회
+
+### 📖 캐시 읽기 전략
+
+**인기 상품 조회 기능**은 `Read Through` 캐싱 패턴을 기반으로 동작한다.  
+서비스는 항상 **Redis 캐시를 우선 조회**하며, 캐시 미스 발생 시 **DB에서 데이터를 조회한 뒤, 해당 결과를 캐시에 자동 저장**한다.
+
+![img_2](https://github.com/user-attachments/assets/defa6860-59e1-45c1-8763-75ddf28f1607)
+
+
++ (1) 사용자가 인기 상품 조회를 요청 한다.
++ (2) `@Cacheable` 어노테이션을 통해 Redis 캐시에서 데이터를 조회한다.
++ (3) 캐시 미스 발생 시 DB에서 데이터를 조회하고, 해당 결과가 Redis에 저장된다. *(⚠️ 의도되지 않은 예외 상황)*
+
+> 단, (3)은 일반적인 캐시 미스라기보다, **배치 실패 등 시스템 장애로 인해 캐시가 사전 적재되지 않은 예외 상황**일 수 있다.  
+> 예를 들어, 배치가 2회 이상 연속 실패하거나 TTL(예: 49시간) 만료 후 캐시가 삭제되면,  
+> 대량의 요청이 동시에 DB로 유입되어 **캐시 스탬피드(Cache Stampede)가** 발생할 수 있다.
+
+```java
+
+@Service
+@RequiredArgsConstructor
+public class RankFacade {
+
+    @Transactional(readOnly = true)
+    @Cacheable(
+        value = CacheType.CacheName.POPULAR_PRODUCT,
+        key = "'top:' + #criteria.top + ':days:' + #criteria.days"
+    )
+    public RankResult.PopularProducts getPopularProducts(RankCriteria.PopularProducts criteria) {
+        return getPopularProducts(criteria.getTop(), criteria.getDays()); // 📌 캐시 미스 시 DB 조회 및 캐시 저장
+    }
+}
+```
+
+### ✍️ 캐시 쓰기 전략
+
+쓰기 전략은 Write Through 방식으로, 배치 기반 캐시 갱신을 사용한다.
+사용자 요청 시점이 아닌, **매일 정해진 시각(00:05)** 에 실행되는 스케줄러가 **DB 저장과 동시에 캐시도 갱신**한다.
+
+![img_1](https://github.com/user-attachments/assets/07a5d3c7-4071-47ab-8a71-f6ce4af5758e)
+
+
+- (1) 매일 00:05, 스케줄러가 실행된다.
+- (2) 전일 주문/결제 데이터를 기반으로 인기 상품을 집계하여 DB에 저장한다.
+- (3), (4) 집계된 데이터를 기준으로 상품 정보를 포함한 인기 상품 데이터를 조회한다.
+- (5) 조회 결과를 `@CachePut`을 통해 Redis에 갱신한다.
+
+```java
+
+@Service
+@RequiredArgsConstructor
+public class RankFacade {
+
+    @Transactional(readOnly = true)
+    @CachePut(
+        value = CacheType.CacheName.POPULAR_PRODUCT,
+        key = "'top:' + #criteria.top + ':days:' + #criteria.days"
+    )
+    public RankResult.PopularProducts updatePopularProducts(RankCriteria.PopularProducts criteria) {
+        return getPopularProducts(criteria.getTop(), criteria.getDays()); // 📌 캐시 갱신용 DB 조회 및 저장
+    }
+}
+```
+
+### ⌛️ 캐시 TTL 전략
+
+캐시 TTL(Time To Live)은 **49시간**으로 설정했다.
+
+![img](https://github.com/user-attachments/assets/29261fa1-0282-4959-96fb-56e8eee052c1)
+
+
+- TTL을 24시간으로 설정할 경우, 매일 00:05에 실행되는 배치와 만료 시점이 겹쳐 **캐시 미스 타이밍 리스크**가 발생할 수 있다.
+- 이를 방지하고, **배치 실패 시 `hotfix`로 캐시를 수동 갱신할 수 있는 여유 시간을 확보하기 위해** TTL을 49시간으로 설정하였다.
+- 일 단위로 캐시를 주기적으로 갱신하므로, 별도의 eviction 정책은 적용하지 않는다.
+
+> 💡 참고  
+> 매일 **00:00 ~ 00:05** 사이에는 캐시 갱신이 아직 반영되지 않았을 수 있다.  
+> 이 시간대에는 "최근 3일"이 아닌, **어제 ~ 4일 전** 기준의 데이터가 조회될 수 있다.  
+> 이는 **비즈니스적으로 허용 가능한 정합성 범위**로 판단하여 수용한다.
+
+```java
+public enum CacheType implements Cacheable {
+
+    POPULAR_PRODUCT("인기 상품 캐싱") {
+        @Override
+        public String cacheName() {
+            return CacheName.POPULAR_PRODUCT;
+        }
+
+        @Override
+        public Duration ttl() {
+            return Duration.ofHours(49); // 📌 TTL : 49시간
+        }
+    }
+}
+```
+
+## 🧪 테스트를 통한 캐싱 검증
+
+캐시 테스트 시 데이터 간섭을 방지하기 위해, Redis 캐시를 클렌징할 수 있는 전용 클래스를 작성하였다.  
+해당 클래스는 테스트 훅 `@AfterEach`를 통해 각 테스트 실행 이후 자동으로 캐시를 정리한다.
+
+```java
+
+@Transactional
+class RankFacadeCacheTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RedisCacheCleaner redisCacheCleaner;
+
+    @AfterEach
+    void tearDown() {
+        redisCacheCleaner.clean(); // 🧹 테스트 후 캐시 클렌징
+    }
+}
+
+```
+
+### ❌ 캐시 미스 시, 캐시 저장 테스트
+
+캐시 미스 시, DB에서 조회한 데이터가 캐시에 저장되는지 확인한다. 
+
+```java
+
+@DisplayName("인기 상품을 캐싱 조회 한다.")
+@Test
+void getPopularProducts() {
+    // given
+    Optional<RankResult.PopularProducts> emptyCached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class);
+
+    // when
+    rankFacade.getPopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
+
+    // then
+    assertThat(emptyCached).isEmpty(); // 미리 캐시가 비어 있었는지 확인
+    RankResult.PopularProducts cached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class).orElseThrow();
+    assertThat(cached.getProducts()).hasSize(3)
+        .extracting("productId")
+        .containsExactly(product3.getId(), product2.getId(), product1.getId());
+}
+```
+
+### 💼 캐싱을 저장하는 테스트
+
+`@CachePut` 어노테이션을 통해 캐시가 저장되는지 확인한다.
+
+```java
+
+@DisplayName("인기 상품을 캐싱 한다.")
+@Test
+void updatePopularProductsForCache() {
+    // given
+    Optional<RankResult.PopularProducts> emptyCached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class);
+
+    // when
+    rankFacade.updatePopularProducts(RankCriteria.PopularProducts.ofTop5Days3()); 
+
+    // then
+    assertThat(emptyCached).isEmpty(); 
+    RankResult.PopularProducts cached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class).orElseThrow();
+    assertThat(cached.getProducts()).hasSize(3)
+        .extracting("productId")
+        .containsExactly(product3.getId(), product2.getId(), product1.getId());
+}
+```
+
+### 🚀 캐싱 갱신 테스트
+
+기존 캐시가 존재하는 상태에서 @CachePut을 통해 값이 덮어써지는지 검증한다.
+
+```java
+
+@DisplayName("인기 상품을 캐시 갱신 한다.")
+@Test
+void updatePopularProductsForRefresh() {
+    // given
+    redisCacheTemplate.put(CacheType.POPULAR_PRODUCT, cacheKey, "test");
+    Optional<String> existCached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, String.class);
+
+    // when
+    rankFacade.updatePopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
+
+    // then
+    assertThat(existCached).isPresent();
+    assertThat(existCached.get()).isEqualTo("test");
+
+    // 캐시가 갱신되었는지 확인
+    RankResult.PopularProducts cached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class).orElseThrow();
+    assertThat(cached.getProducts()).hasSize(3)
+        .extracting("productId")
+        .containsExactly(product3.getId(), product2.getId(), product1.getId());
+}
+```
+
+### ✅ 테스트 결과 
+
+모든 테스트가 성공적으로 통과하며, 캐시 조회/저장/갱신이 의도대로 동작함을 검증하였다.
+
+![img_3](https://github.com/user-attachments/assets/5f61c750-b761-4ea8-a205-d285b2b5adba)
+
+
+## 🏎️ 캐시 성능 비교 
+
+캐시 성능을 검증하기 위해 K6(성능 및 부하 테스트), InfluxDB(메트릭 수집), Grafana(시각화)를 활용하여 성능 테스트를 수행하였다.  
+주요 목적은 캐시 적용 전후의 응답 속도 및 처리량 차이를 측정하여, 캐시 도입의 효과를 검증하는 것이다.
+
+> 본 테스트는 로컬 환경에서 수행되었으며, 향후에는 운영 환경과 유사한 조건에서의 검증이 추가로 필요하다.
+
+### 🗃️️ 테스트 케이스
+
+총 2가지 케이스를 기준으로 테스트를 수행하였다.
+
+#### ☝️ [CASE 1] 캐싱 미적용 - DB 단순 조회
+
+`@Cacheable` 어노테이션을 제거한 상태에서, 단순히 DB를 직접 조회한다.
+
+```java
+@Transactional(readOnly = true)
+// @Cacheable(value = CacheType.CacheName.POPULAR_PRODUCT, key = "'top:' + #criteria.top + ':days:' + #criteria.days")
+public RankResult.PopularProducts getPopularProducts(RankCriteria.PopularProducts criteria) {
+    return getPopularProducts(criteria.getTop(), criteria.getDays());
+}
+```
+
+#### ✌️ [CASE 2] 캐싱 적용 - Redis 기반 캐시 조회
+
+`@Cacheable` 어노테이션을 활성화하여, Redis에 저장된 데이터를 조회한다.
+
+```java
+@Transactional(readOnly = true)
+@Cacheable(value = CacheType.CacheName.POPULAR_PRODUCT, key = "'top:' + #criteria.top + ':days:' + #criteria.days")
+public RankResult.PopularProducts getPopularProducts(RankCriteria.PopularProducts criteria) {
+    return getPopularProducts(criteria.getTop(), criteria.getDays());
+}
+```
+
+### 📜 테스트 시나리오
+
+가상의 사용자(Virtual User)가 반복적으로 인기 상품 조회 API를 호출하는 테스트 시나리오를 구성하였다.
+총 테스트 시간은 70초이며, 다음과 같이 단계적으로 부하를 증가 및 감소시키며 성능을 측정하였다.
+
++ 0초~10초: 0 → 25명으로 증가
++ 10초~20초: 25 → 50명으로 증가
++ 20초~30초: 50 → 100명으로 증가
++ 30초~40초: 100명 유지
++ 40초~50초: 100 → 50명으로 감소
++ 50초~60초: 50 → 25명으로 감소
++ 60초~70초: 25 → 0명으로 감소
+
+### 🧪 테스트 결과
+
+#### ☝️ DB 단순 조회 (캐싱 미적용)
+
+![img_5](https://github.com/user-attachments/assets/abe33c64-7ddf-4cc8-ac41-9f17bfe29511)
+
+
++ 총 요청 수: 3,371건
++ 평균 응답 시간: 54.04ms
++ p95 응답 시간: 169.19ms
++ 오류율: 0%
+
+> 응답 시간은 30~150ms에 분포하였으며, 최대 321ms까지 지연이 발생하였다.
+
+#### ✌️ 캐시 조회 (@Cacheable 적용)
+
+![img_4](https://github.com/user-attachments/assets/7c37afd7-70c8-4379-9bdb-28d48d239a10)
+
+
++ 총 요청 수: 3,541건
++ 평균 응답 시간: 2.1ms
++ p95 응답 시간: 5.4ms
++ 오류율: 0%
+
+> 대부분의 요청이 0~5ms 이내에 응답되었으며, Redis 캐시 히트가 효과적으로 작동함을 확인하였다.
+
+#### 📈 응답 시간 비교 
+
+| 구분             | DB 조회     | 캐시 조회   | 성능 개선 |
+|----------------|-----------|---------|-------|
+| 평균 응답시간        | 54.04 ms  | 2.1 ms  | 25.7배 |
+| 중앙값 (Median)   | 34.41 ms  | 1.28 ms | 26.9배 |
+| 최소 응답시간        | 17.74 ms  | 410 µs  | 43.3배 |
+| 최대 응답시간        | 321.52 ms | 94.7 ms | 3.4배  |
+| 90% 응답시간 (p90) | 113.4 ms  | 3.19 ms | 35.5배 |
+| 95% 응답시간 (p95) | 169.19 ms | 5.4 ms  | 31.3배 |
+
+> p90/p95는 각각 상위 90%, 95%의 요청이 해당 시간 이하로 응답되었음을 의미한다.
+
+#### 📊 처리량 비교
+
+| 지표             | DB 조회     | 캐시 조회     | 성능 개선   |
+|----------------|-----------|-----------|---------|
+| 총 요청 처리        | 3,371건    | 3,541건    | 5.0% 증가 |
+| 초당 요청 처리 (RPS) | 47.73 / 초 | 50.36 / 초 | 5.5% 증가 |
+
+#### ✅ 결과 요약 
+
++ 응답 시간: 평균 기준 약 25.7배 개선되었고, p95 기준으로도 31배 이상 개선되었다.
++ 처리량: Redis 캐시 적용 후 약 5% 더 많은 요청을 처리하여 시스템 처리 효율이 향상되었음을 확인할 수 있다.
+
+## 🚧 한계
+
+### 1️⃣ @Cacheable 어노테이션의 한계
+
+현재 사용 중인 @Cacheable 어노테이션은 Redis 장애 발생 시 자동으로 DB로 우회(fallback) 하는 기능이 없다.  
+이로 인해 Redis에 문제가 발생하면, 전체 서비스의 응답 지연 또는 장애로 확산될 수 있는 구조적 리스크가 존재한다.
+
+이를 보완하기 위해 resilience4j 등의 라이브러리를 활용해 Circuit Breaker 패턴을 적용하면,  
+Redis 접근 실패 시 DB로 우회하거나 즉시 실패 응답을 반환하는 등 유연한 장애 대응이 가능하다.
+
+또한 Redis의 역할을 분산 락용 Redis와 캐시용 Redis로 물리적으로 분리하면, 각 역할의 부하를 독립적으로 관리할 수 있다.
+
+### 2️⃣ Redis 부하로 인한 병목 현상
+
+요청량이 증가하거나 TTL이 짧은 경우, Redis에 대한 네트워크 I/O가 집중되면서 병목 현상이 발생할 수 있다.  
+특히 캐시 미스가 자주 발생하면, Redis가 반복적으로 DB 접근을 유도하게 되어 오히려 전체 시스템의 성능이 저하될 수 있다.
+
+이를 해결하기 위해 Caffeine과 같은 로컬 캐시를 Redis 앞단에 배치한 Multi Cache Layer 구조를 도입할 수 있다.  
+자주 반복되는 요청은 로컬 캐시에서 응답하도록 하여, Redis 부하를 분산하고 전반적인 처리 성능을 극대화할 수 있다.
+
+## ✅ 결론
+
+이번 전략을 통해 Redis 기반 캐시 도입이 인기 상품 조회 기능의 응답 속도 및 처리량을 크게 개선함을 확인할 수 있었다.  
+이처럼 캐시는 시스템 성능을 높이는 핵심 도구이자, 서비스 운영 효율을 극대화하는 필수 요소로 자리 잡았다.
+
+단, 캐시 적용 시에는 데이터 정합성과 캐시 갱신 주기, TTL 관리, 스탬피드 대응 등 다양한 요소를 함께 고려해야 하며,  
+서비스 특성과 비즈니스 요구에 맞는 정교한 캐싱 전략이 필요하다. 
+
+캐시 적용 이후에는 정기적으로 캐시 적중률(Hit Rate)과 미스(Miss) 비율을 모니터링하여,   
+캐시 성능을 지속적으로 개선할 수 있는 방안을 마련해야 한다.
+
+또한, 서비스 규모가 커짐에 따라 Redis에 대한 의존성과 부하가 증가하는 한계점이 드러날 수 있다.  
+따라서 Redis 부하를 분산하기 위해 Warm-up 전략으로 캐시를 미리 적재하거나,  
+로컬 캐시를 활용한 Multi Cache Layer 구조를 도입해 성능을 극대화할 수 있다.
+

--- a/k6/cache/rank.js
+++ b/k6/cache/rank.js
@@ -1,0 +1,29 @@
+import http from 'k6/http';
+import { sleep, check, group } from "k6";
+
+export const options = {
+    stages: [
+        { duration: '10s', target: 25 },
+        { duration: '10s',target: 50 },
+        { duration: '10s', target: 100 },
+        { duration: '10s', target: 100 },
+        { duration: '10s',target: 50 },
+        { duration: '10s', target: 25 },
+        { duration: '10s', target: 0 }
+    ],
+};
+
+export default function main() {
+
+    group("인기상품 캐싱 성능 테스트", function () {
+        let url = 'http://127.0.0.1:8080/api/v1/products/ranks';
+
+        const res = http.get(url);
+
+        check(res, {
+            '응답 상태 200': (r) => r.status === 200
+        });
+    });
+
+    sleep(1);
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/application/product/ProductFacade.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/product/ProductFacade.java
@@ -1,49 +1,23 @@
 package kr.hhplus.be.ecommerce.application.product;
 
-import kr.hhplus.be.ecommerce.domain.product.ProductCommand;
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo;
 import kr.hhplus.be.ecommerce.domain.product.ProductService;
-import kr.hhplus.be.ecommerce.domain.rank.RankCommand;
-import kr.hhplus.be.ecommerce.domain.rank.RankInfo;
-import kr.hhplus.be.ecommerce.domain.rank.RankService;
 import kr.hhplus.be.ecommerce.domain.stock.StockInfo;
 import kr.hhplus.be.ecommerce.domain.stock.StockService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 @Service
 @RequiredArgsConstructor
 public class ProductFacade {
 
-    private static final int RECENT_DAYS = 3;
-    private static final int TOP_LIMIT = 5;
-
     private final ProductService productService;
     private final StockService stockService;
-    private final RankService rankService;
 
     @Transactional(readOnly = true)
     public ProductResult.Products getProducts() {
         ProductInfo.Products products = productService.getSellingProducts();
-        return ProductResult.Products.of(products.getProducts().stream()
-            .map(this::getProduct)
-            .toList());
-    }
-
-    @Transactional(readOnly = true)
-    public ProductResult.Products getPopularProducts() {
-        LocalDate endDate = LocalDate.now();
-        LocalDate startDate = endDate.minusDays(RECENT_DAYS);
-
-        RankCommand.PopularSellRank popularSellRankCommand = RankCommand.PopularSellRank.of(TOP_LIMIT, startDate, endDate);
-        RankInfo.PopularProducts popularProducts = rankService.getPopularSellRank(popularSellRankCommand);
-
-        ProductCommand.Products productsCommand = ProductCommand.Products.of(popularProducts.getProductIds());
-        ProductInfo.Products products = productService.getProducts(productsCommand);
-
         return ProductResult.Products.of(products.getProducts().stream()
             .map(this::getProduct)
             .toList());
@@ -59,5 +33,4 @@ public class ProductFacade {
             .quantity(stock.getQuantity())
             .build();
     }
-
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/application/rank/RankConstant.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/rank/RankConstant.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.ecommerce.application.rank;
+
+public class RankConstant {
+
+    public static final int TOP_5 = 5;
+    public static final int DAYS_3 = 3;
+
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/application/rank/RankCriteria.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/rank/RankCriteria.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.ecommerce.application.rank;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankCriteria {
+
+    @Getter
+    public static class PopularProducts {
+
+        private final int top;
+        private final int days;
+
+        private PopularProducts(int top, int days) {
+            this.top = top;
+            this.days = days;
+        }
+
+        public static PopularProducts of(int top, int days) {
+            return new PopularProducts(top, days);
+        }
+
+        public static PopularProducts ofTop5Days3() {
+            return new PopularProducts(RankConstant.TOP_5, RankConstant.DAYS_3);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/application/rank/RankResult.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/rank/RankResult.java
@@ -1,0 +1,50 @@
+package kr.hhplus.be.ecommerce.application.rank;
+
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankResult {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class PopularProducts {
+
+        private List<PopularProduct> products;
+
+        private PopularProducts(List<PopularProduct> products) {
+            this.products = products;
+        }
+
+        public static PopularProducts of(List<PopularProduct> products) {
+            return new PopularProducts(products);
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class PopularProduct {
+
+        private Long productId;
+        private String productName;
+        private Long productPrice;
+
+        @Builder
+        private PopularProduct(Long productId, String productName, Long productPrice) {
+            this.productId = productId;
+            this.productName = productName;
+            this.productPrice = productPrice;
+        }
+
+        public static PopularProduct of(Long productId, String productName, Long productPrice) {
+            return PopularProduct.builder()
+                .productId(productId)
+                .productName(productName)
+                .productPrice(productPrice)
+                .build();
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/application/user/UserCouponFacade.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/application/user/UserCouponFacade.java
@@ -5,6 +5,9 @@ import kr.hhplus.be.ecommerce.domain.coupon.CouponService;
 import kr.hhplus.be.ecommerce.domain.user.UserCouponInfo;
 import kr.hhplus.be.ecommerce.domain.user.UserCouponService;
 import kr.hhplus.be.ecommerce.domain.user.UserService;
+import kr.hhplus.be.ecommerce.support.lock.DistributedLock;
+import kr.hhplus.be.ecommerce.support.lock.LockStrategy;
+import kr.hhplus.be.ecommerce.support.lock.LockType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +23,7 @@ public class UserCouponFacade {
     private final UserCouponService userCouponService;
 
     @Transactional
+    @DistributedLock(type = LockType.COUPON, key = "#criteria.couponId", strategy = LockStrategy.SPIN_LOCK)
     public void publishUserCoupon(UserCouponCriteria.Publish criteria) {
         userService.getUser(criteria.getUserId());
 

--- a/src/main/java/kr/hhplus/be/ecommerce/config/JpaConfig.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.ecommerce.config.jpa;
+package kr.hhplus.be.ecommerce.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/src/main/java/kr/hhplus/be/ecommerce/config/RedisCacheConfig.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/config/RedisCacheConfig.java
@@ -1,0 +1,63 @@
+package kr.hhplus.be.ecommerce.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import kr.hhplus.be.ecommerce.support.cache.CacheType;
+import kr.hhplus.be.ecommerce.support.cache.Cacheable;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    private static final Duration DEFAULT_TTL = Duration.ofHours(1);
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration defaultConfig = getConfigWith(DEFAULT_TTL);
+
+        Map<String, RedisCacheConfiguration> configs = Arrays.stream(CacheType.values())
+            .map(this::createConfig)
+            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(configs)
+            .build();
+    }
+
+    private Map.Entry<String, RedisCacheConfiguration> createConfig(Cacheable cacheable) {
+        RedisCacheConfiguration config = getConfigWith(cacheable.ttl());
+        return Map.entry(cacheable.cacheName(), config);
+    }
+
+    private RedisCacheConfiguration getConfigWith(Duration ttl) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper())))
+            .entryTtl(ttl);
+    }
+
+    private ObjectMapper objectMapper() {
+        return new ObjectMapper()
+            .activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL
+            );
+    }
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/config/RedisRedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/config/RedisRedissonConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class RedissonConfig {
+public class RedisRedissonConfig {
 
     @Value("${spring.data.redis.host}")
     private String redisHost;

--- a/src/main/java/kr/hhplus/be/ecommerce/config/SchedulerConfig.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/config/SchedulerConfig.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.ecommerce.config.scheduler;
+package kr.hhplus.be.ecommerce.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/src/main/java/kr/hhplus/be/ecommerce/infrastructure/cache/RedisCacheTemplate.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/infrastructure/cache/RedisCacheTemplate.java
@@ -1,0 +1,70 @@
+package kr.hhplus.be.ecommerce.infrastructure.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import kr.hhplus.be.ecommerce.support.cache.CacheTemplate;
+import kr.hhplus.be.ecommerce.support.cache.Cacheable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static java.lang.Boolean.FALSE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisCacheTemplate implements CacheTemplate {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public <T> Optional<T> get(Cacheable cacheable, String key, Class<T> type) {
+        String createdKey = cacheable.createKey(key);
+
+        return Optional.ofNullable(redisTemplate.opsForValue().get(createdKey))
+            .map(value -> deserialize(value, type));
+    }
+
+    @Override
+    public <T> void put(Cacheable cacheable, String key, T value) {
+        String createdKey = cacheable.createKey(key);
+        redisTemplate.opsForValue().set(createdKey, serialize(value), cacheable.ttl());
+    }
+
+    @Override
+    public void evict(Cacheable cacheable, String key) {
+        String createdKey = cacheable.createKey(key);
+        Boolean deleted = redisTemplate.delete(createdKey);
+
+        if (FALSE.equals(deleted)) {
+            log.debug("삭제할 캐시가 존재하지 않습니다. key: {}", createdKey);
+        }
+    }
+
+    private <T> T deserialize(String value, Class<T> type) {
+        try {
+            return objectMapper().readValue(value, type);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("캐싱 값을 역직렬화하는데 실패했습니다. " + type.getSimpleName(), e);
+        }
+    }
+
+    private <T> String serialize(T value) {
+        try {
+            return objectMapper().writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("캐싱 값을 직렬화하는데 실패했습니다.", e);
+        }
+    }
+
+    private ObjectMapper objectMapper() {
+        return new ObjectMapper()
+            .activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL
+            );
+    }
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductController.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductController.java
@@ -18,10 +18,4 @@ public class ProductController {
         ProductResult.Products products = productFacade.getProducts();
         return ApiResponse.success(ProductResponse.Products.of(products));
     }
-
-    @GetMapping("/api/v1/products/ranks")
-    public ApiResponse<ProductResponse.Products> getPopularProducts() {
-        ProductResult.Products products = productFacade.getPopularProducts();
-        return ApiResponse.success(ProductResponse.Products.of(products));
-    }
 }

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductResponse.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/product/ProductResponse.java
@@ -15,22 +15,22 @@ public class ProductResponse {
     @NoArgsConstructor
     public static class Products {
 
-        private List<ProductV1> products;
+        private List<Product> products;
 
-        private Products(List<ProductV1> products) {
+        private Products(List<Product> products) {
             this.products = products;
         }
 
         public static Products of(ProductResult.Products products) {
             return new Products(products.getProducts().stream()
-                .map(ProductV1::of)
+                .map(Product::of)
                 .toList());
         }
     }
 
     @Getter
     @NoArgsConstructor
-    public static class ProductV1 {
+    public static class Product {
 
         private Long id;
         private String name;
@@ -38,15 +38,15 @@ public class ProductResponse {
         private int stock;
 
         @Builder
-        private ProductV1(Long id, String name, long price, int stock) {
+        private Product(Long id, String name, long price, int stock) {
             this.id = id;
             this.name = name;
             this.price = price;
             this.stock = stock;
         }
 
-        public static ProductV1 of(ProductResult.Product product) {
-            return ProductV1.builder()
+        public static Product of(ProductResult.Product product) {
+            return Product.builder()
                 .id(product.getProductId())
                 .name(product.getProductName())
                 .price(product.getProductPrice())

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/rank/RankController.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/rank/RankController.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.ecommerce.interfaces.rank;
+
+import kr.hhplus.be.ecommerce.application.rank.RankCriteria;
+import kr.hhplus.be.ecommerce.application.rank.RankFacade;
+import kr.hhplus.be.ecommerce.application.rank.RankResult;
+import kr.hhplus.be.ecommerce.interfaces.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RankController {
+
+    private final RankFacade rankFacade;
+
+    @GetMapping("/api/v1/products/ranks")
+    public ApiResponse<RankResponse.PopularProducts> getPopularProducts() {
+        RankResult.PopularProducts popularProducts = rankFacade.getPopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
+        return ApiResponse.success(RankResponse.PopularProducts.of(popularProducts));
+    }
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/rank/RankResponse.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/rank/RankResponse.java
@@ -1,0 +1,54 @@
+package kr.hhplus.be.ecommerce.interfaces.rank;
+
+import kr.hhplus.be.ecommerce.application.rank.RankResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankResponse {
+
+    @Getter
+    @NoArgsConstructor
+    public static class PopularProducts {
+
+        private List<PopularProduct> products;
+
+        private PopularProducts(List<PopularProduct> products) {
+            this.products = products;
+        }
+
+        public static PopularProducts of(RankResult.PopularProducts products) {
+            return new PopularProducts(products.getProducts().stream()
+                .map(PopularProduct::of)
+                .toList());
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class PopularProduct {
+
+        private Long id;
+        private String name;
+        private long price;
+
+        @Builder
+        private PopularProduct(Long id, String name, long price) {
+            this.id = id;
+            this.name = name;
+            this.price = price;
+        }
+
+        public static PopularProduct of(RankResult.PopularProduct product) {
+            return PopularProduct.builder()
+                .id(product.getProductId())
+                .name(product.getProductName())
+                .price(product.getProductPrice())
+                .build();
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/interfaces/rank/RankScheduler.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/interfaces/rank/RankScheduler.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.ecommerce.interfaces.rank;
 
+import kr.hhplus.be.ecommerce.application.rank.RankCriteria;
 import kr.hhplus.be.ecommerce.application.rank.RankFacade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,13 +16,15 @@ public class RankScheduler {
 
     private final RankFacade rankFacade;
 
-    @Scheduled(cron = "0 0 1 * * *")
+    @Scheduled(cron = "0 5 0 * * *")
     public void createDailyRank() {
         log.info("일별 판매 랭크 생성 스케줄러 실행");
         try {
             LocalDate yesterday = LocalDate.now().minusDays(1);
             rankFacade.createDailyRankAt(yesterday);
             log.info("일별 판매 랭크 생성 완료: {}", yesterday);
+
+            rankFacade.updatePopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
         } catch (Exception e) {
             log.error("일별 판매 랭크 생성 스케줄러 실행 중 오류 발생", e);
         }

--- a/src/main/java/kr/hhplus/be/ecommerce/support/cache/CacheTemplate.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/support/cache/CacheTemplate.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.ecommerce.support.cache;
+
+import java.util.Optional;
+
+public interface CacheTemplate {
+
+    <T> Optional<T> get(Cacheable cacheable, String key, Class<T> type);
+
+    <T> void put(Cacheable cacheable, String key, T value);
+
+    void evict(Cacheable cacheable, String key);
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/support/cache/CacheType.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/support/cache/CacheType.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.ecommerce.support.cache;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType implements Cacheable {
+
+    POPULAR_PRODUCT("인기 상품 캐싱") {
+        @Override
+        public String cacheName() {
+            return CacheName.POPULAR_PRODUCT;
+        }
+
+        @Override
+        public Duration ttl() {
+            return Duration.ofHours(49);
+        }
+    },
+    ;
+
+    private final String description;
+
+    @Override
+    public String createKey(String key) {
+        return cacheName() + "::" + key;
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class CacheName {
+
+        public static final String POPULAR_PRODUCT = "popular-product";
+    }
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/support/cache/Cacheable.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/support/cache/Cacheable.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.ecommerce.support.cache;
+
+import java.time.Duration;
+
+public interface Cacheable {
+
+    String createKey(String key);
+
+    String cacheName();
+
+    Duration ttl();
+}

--- a/src/main/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilter.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilter.java
@@ -12,10 +12,13 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 @Slf4j
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "X-Trace-Id";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -24,34 +27,35 @@ public class LoggingFilter extends OncePerRequestFilter {
         ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
         ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
+        String traceId = UUID.randomUUID().toString();
+        responseWrapper.setHeader(TRACE_ID, traceId);
+
         long startTime = System.currentTimeMillis();
 
         try {
             filterChain.doFilter(requestWrapper, responseWrapper);
         } finally {
-            logRequest(requestWrapper);
-
             long duration = System.currentTimeMillis() - startTime;
-            logResponse(responseWrapper, duration);
+            logRequestResponse(requestWrapper, responseWrapper, duration, traceId);
 
             responseWrapper.copyBodyToResponse();
         }
     }
 
-    private void logRequest(ContentCachingRequestWrapper request) {
+    private void logRequestResponse(ContentCachingRequestWrapper request,
+                                    ContentCachingResponseWrapper response,
+                                    long duration,
+                                    String traceId) {
         String ip = request.getRemoteAddr();
         String method = request.getMethod();
         String url = request.getRequestURL().toString();
         String requestBody = getContent(request.getContentAsByteArray());
-
-        log.info("[REQUEST] IP: {}, Method: {}, URL: {}, Body: {}", ip, method, url, requestBody);
-    }
-
-    private void logResponse(ContentCachingResponseWrapper response, long duration) {
         int status = response.getStatus();
         String responseBody = getContent(response.getContentAsByteArray());
 
-        log.info("[RESPONSE] Duration: {}ms, Status: {}, Body: {}", duration, status, responseBody);
+        log.info("[API] traceId: {}, ip: {}, method: {}, url: {}, status: {}, latency: {}ms request: {}, response: {}",
+            traceId, ip, method, url, status, duration, requestBody, responseBody
+        );
     }
 
     private String getContent(byte[] content) {

--- a/src/main/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilter.java
+++ b/src/main/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilter.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.ecommerce.config.web;
+package kr.hhplus.be.ecommerce.support.filter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,8 +31,6 @@ spring:
     password: application
   jpa:
     show-sql: true
-    hibernate:
-      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
@@ -40,3 +38,12 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+---
+spring.config.activate.on-profile: test
+
+spring:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create

--- a/src/test/java/kr/hhplus/be/ecommerce/EcommerceApplicationTests.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/EcommerceApplicationTests.java
@@ -1,10 +1,11 @@
 package kr.hhplus.be.ecommerce;
 
+import kr.hhplus.be.ecommerce.support.ContainerTestSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class EcommerceApplicationTests {
+class EcommerceApplicationTests extends ContainerTestSupport {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductFacadeIntegrationTest.java
@@ -75,9 +75,9 @@ class ProductFacadeIntegrationTest extends IntegrationTestSupport {
     void getPopularProducts() {
         // given
         List<Rank> ranks = List.of(
-            Rank.createSell(product1.getId(), LocalDate.of(2025, 4, 23), 10L),
-            Rank.createSell(product2.getId(), LocalDate.of(2025, 4, 22), 34L),
-            Rank.createSell(product3.getId(), LocalDate.of(2025, 4, 23), 42L)
+            Rank.createSell(product1.getId(), LocalDate.now().minusDays(1), 10L),
+            Rank.createSell(product2.getId(), LocalDate.now().minusDays(1), 34L),
+            Rank.createSell(product3.getId(), LocalDate.now().minusDays(2), 42L)
         );
 
         ranks.forEach(rankRepository::save);

--- a/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductFacadeIntegrationTest.java
@@ -3,8 +3,6 @@ package kr.hhplus.be.ecommerce.application.product;
 import kr.hhplus.be.ecommerce.domain.product.Product;
 import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
 import kr.hhplus.be.ecommerce.domain.product.ProductSellingStatus;
-import kr.hhplus.be.ecommerce.domain.rank.Rank;
-import kr.hhplus.be.ecommerce.domain.rank.RankRepository;
 import kr.hhplus.be.ecommerce.domain.stock.Stock;
 import kr.hhplus.be.ecommerce.domain.stock.StockRepository;
 import kr.hhplus.be.ecommerce.support.IntegrationTestSupport;
@@ -14,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,9 +27,6 @@ class ProductFacadeIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private StockRepository stockRepository;
-
-    @Autowired
-    private RankRepository rankRepository;
 
     private Product product1;
 
@@ -55,7 +49,6 @@ class ProductFacadeIntegrationTest extends IntegrationTestSupport {
 
         List.of(stock1, stock2, stock3)
             .forEach(stockRepository::save);
-
     }
 
     @DisplayName("판매 가능 상품 목록을 조회한다.")
@@ -68,26 +61,5 @@ class ProductFacadeIntegrationTest extends IntegrationTestSupport {
         assertThat(products.getProducts()).hasSize(2)
             .extracting(ProductResult.Product::getProductId)
             .containsExactlyInAnyOrder(product1.getId(), product2.getId());
-    }
-
-    @DisplayName("상위 상품을 조회한다.")
-    @Test
-    void getPopularProducts() {
-        // given
-        List<Rank> ranks = List.of(
-            Rank.createSell(product1.getId(), LocalDate.now().minusDays(1), 10L),
-            Rank.createSell(product2.getId(), LocalDate.now().minusDays(1), 34L),
-            Rank.createSell(product3.getId(), LocalDate.now().minusDays(2), 42L)
-        );
-
-        ranks.forEach(rankRepository::save);
-
-        // when
-        ProductResult.Products products = productFacade.getPopularProducts();
-
-        // then
-        assertThat(products.getProducts()).hasSize(3)
-            .extracting("productId")
-            .containsExactly(product3.getId(), product2.getId(), product1.getId());
     }
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductFacadeUnitTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/product/ProductFacadeUnitTest.java
@@ -2,8 +2,6 @@ package kr.hhplus.be.ecommerce.application.product;
 
 import kr.hhplus.be.ecommerce.domain.product.ProductInfo;
 import kr.hhplus.be.ecommerce.domain.product.ProductService;
-import kr.hhplus.be.ecommerce.domain.rank.RankInfo;
-import kr.hhplus.be.ecommerce.domain.rank.RankService;
 import kr.hhplus.be.ecommerce.domain.stock.StockInfo;
 import kr.hhplus.be.ecommerce.domain.stock.StockService;
 import kr.hhplus.be.ecommerce.support.MockTestSupport;
@@ -30,9 +28,6 @@ class ProductFacadeUnitTest extends MockTestSupport {
 
     @Mock
     private StockService stockService;
-
-    @Mock
-    private RankService rankService;
 
     @DisplayName("판매 가능 상품 목록을 조회한다.")
     @Test
@@ -75,79 +70,6 @@ class ProductFacadeUnitTest extends MockTestSupport {
             .containsExactlyInAnyOrder(
                 tuple(1L, 10),
                 tuple(2L, 10)
-            );
-    }
-
-    @DisplayName("최근 3일 가장 많이 팔린 상위 상품 5개를 조회한다.")
-    @Test
-    void getPopularProducts() {
-        // given
-        RankInfo.PopularProducts rankPopularProducts = RankInfo.PopularProducts.of(List.of(
-            RankInfo.PopularProduct.of(1L, 120L),  // 1등 상품
-            RankInfo.PopularProduct.of(2L, 95L),   // 2등 상품
-            RankInfo.PopularProduct.of(3L, 87L),   // 3등 상품
-            RankInfo.PopularProduct.of(4L, 76L),   // 4등 상품
-            RankInfo.PopularProduct.of(5L, 65L)   // 5등 상품
-        ));
-        when(rankService.getPopularSellRank(any()))
-            .thenReturn(rankPopularProducts);
-
-        ProductInfo.Products products = ProductInfo.Products.of(List.of(
-            ProductInfo.Product.builder()
-                .productId(1L)
-                .productName("상품명1")
-                .productPrice(1_000L)
-                .build(),
-            ProductInfo.Product.builder()
-                .productId(2L)
-                .productName("상품명2")
-                .productPrice(2_000L)
-                .build(),
-            ProductInfo.Product.builder()
-                .productId(3L)
-                .productName("상품명3")
-                .productPrice(3_000L)
-                .build(),
-            ProductInfo.Product.builder()
-                .productId(4L)
-                .productName("상품명4")
-                .productPrice(4_000L)
-                .build(),
-            ProductInfo.Product.builder()
-                .productId(5L)
-                .productName("상품명5")
-                .productPrice(5_000L)
-                .build()
-        ));
-
-        when(productService.getProducts(any()))
-            .thenReturn(products);
-
-        when(stockService.getStock(anyLong()))
-            .thenReturn(StockInfo.Stock.of(1L, 10))
-            .thenReturn(StockInfo.Stock.of(2L, 10))
-            .thenReturn(StockInfo.Stock.of(3L, 10))
-            .thenReturn(StockInfo.Stock.of(4L, 10))
-            .thenReturn(StockInfo.Stock.of(5L, 10));
-
-
-        // when
-        ProductResult.Products popularProducts = productFacade.getPopularProducts();
-
-        // then
-        InOrder inOrder = inOrder(rankService, productService, stockService);
-        inOrder.verify(rankService, times(1)).getPopularSellRank(any());
-        inOrder.verify(productService, times(1)).getProducts(any());
-        inOrder.verify(stockService, times(5)).getStock(anyLong());
-
-        assertThat(popularProducts.getProducts()).hasSize(5)
-            .extracting("productId", "productName", "productPrice")
-            .containsExactly(
-                tuple(1L, "상품명1", 1_000L),
-                tuple(2L, "상품명2", 2_000L),
-                tuple(3L, "상품명3", 3_000L),
-                tuple(4L, "상품명4", 4_000L),
-                tuple(5L, "상품명5", 5_000L)
             );
     }
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/application/rank/RankFacadeCacheTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/rank/RankFacadeCacheTest.java
@@ -1,0 +1,129 @@
+package kr.hhplus.be.ecommerce.application.rank;
+
+import kr.hhplus.be.ecommerce.domain.product.Product;
+import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
+import kr.hhplus.be.ecommerce.domain.product.ProductSellingStatus;
+import kr.hhplus.be.ecommerce.domain.rank.Rank;
+import kr.hhplus.be.ecommerce.domain.rank.RankRepository;
+import kr.hhplus.be.ecommerce.infrastructure.cache.RedisCacheTemplate;
+import kr.hhplus.be.ecommerce.support.IntegrationTestSupport;
+import kr.hhplus.be.ecommerce.support.cache.CacheType;
+import kr.hhplus.be.ecommerce.support.database.RedisCacheCleaner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+class RankFacadeCacheTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RankFacade rankFacade;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private RankRepository rankRepository;
+
+    @Autowired
+    private RedisCacheTemplate redisCacheTemplate;
+
+    @Autowired
+    private RedisCacheCleaner redisCacheCleaner;
+    
+    private final String cacheKey = "top:5:days:3";
+
+    private Product product1;
+
+    private Product product2;
+
+    private Product product3;
+
+    @BeforeEach
+    void setUp() {
+        product1 = Product.create("상품명1", 1_000L, ProductSellingStatus.SELLING);
+        product2 = Product.create("상품명2", 2_000L, ProductSellingStatus.SELLING);
+        product3 = Product.create("상품명3", 3_000L, ProductSellingStatus.STOP_SELLING);
+
+        List.of(product1, product2, product3)
+            .forEach(productRepository::save);
+
+        List<Rank> ranks = List.of(
+            Rank.createSell(product1.getId(), LocalDate.now().minusDays(1), 10L),
+            Rank.createSell(product2.getId(), LocalDate.now().minusDays(1), 34L),
+            Rank.createSell(product3.getId(), LocalDate.now().minusDays(2), 42L)
+        );
+
+        ranks.forEach(rankRepository::save);
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisCacheCleaner.clean();
+    }
+
+    @DisplayName("인기 상품을 캐싱 조회 한다.")
+    @Test
+    void getPopularProducts() {
+        // given
+        Optional<RankResult.PopularProducts> emptyCached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class);
+
+        // when
+        rankFacade.getPopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
+
+        // then
+        assertThat(emptyCached).isEmpty();
+
+        RankResult.PopularProducts cached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class).orElseThrow();
+        assertThat(cached.getProducts()).hasSize(3)
+            .extracting("productId")
+            .containsExactly(product3.getId(), product2.getId(), product1.getId());
+    }
+
+    @DisplayName("인기 상품을 캐싱 한다.")
+    @Test
+    void updatePopularProductsForCache() {
+        // given
+        Optional<RankResult.PopularProducts> emptyCached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class);
+
+        // when
+        rankFacade.updatePopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
+
+        // then
+        assertThat(emptyCached).isEmpty();
+
+        RankResult.PopularProducts cached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class).orElseThrow();
+        assertThat(cached.getProducts()).hasSize(3)
+            .extracting("productId")
+            .containsExactly(product3.getId(), product2.getId(), product1.getId());
+    }
+
+    @DisplayName("인기 상품을 캐시 갱신 한다.")
+    @Test
+    void updatePopularProductsForRefresh() {
+        // given
+        redisCacheTemplate.put(CacheType.POPULAR_PRODUCT, cacheKey, "test");
+        Optional<String> existCached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, String.class);
+
+        // when
+        rankFacade.updatePopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
+
+        // then
+        assertThat(existCached).isPresent();
+        assertThat(existCached.get()).isEqualTo("test");
+
+        RankResult.PopularProducts cached = redisCacheTemplate.get(CacheType.POPULAR_PRODUCT, cacheKey, RankResult.PopularProducts.class).orElseThrow();
+        assertThat(cached.getProducts()).hasSize(3)
+            .extracting("productId")
+            .containsExactly(product3.getId(), product2.getId(), product1.getId());
+    }
+}

--- a/src/test/java/kr/hhplus/be/ecommerce/application/rank/RankFacadeUnitTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/application/rank/RankFacadeUnitTest.java
@@ -2,6 +2,9 @@ package kr.hhplus.be.ecommerce.application.rank;
 
 import kr.hhplus.be.ecommerce.domain.order.OrderInfo;
 import kr.hhplus.be.ecommerce.domain.order.OrderService;
+import kr.hhplus.be.ecommerce.domain.product.ProductInfo;
+import kr.hhplus.be.ecommerce.domain.product.ProductService;
+import kr.hhplus.be.ecommerce.domain.rank.RankInfo;
 import kr.hhplus.be.ecommerce.domain.rank.RankService;
 import kr.hhplus.be.ecommerce.support.MockTestSupport;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +16,8 @@ import org.mockito.Mock;
 import java.time.LocalDate;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -26,6 +31,9 @@ class RankFacadeUnitTest extends MockTestSupport {
 
     @Mock
     private RankService rankService;
+
+    @Mock
+    private ProductService productService;
 
     @DisplayName("일별 랭킹을 생성한다.")
     @Test
@@ -50,6 +58,70 @@ class RankFacadeUnitTest extends MockTestSupport {
         InOrder inOrder = inOrder(orderService, rankService);
         inOrder.verify(orderService, times(1)).getPaidProducts(any());
         inOrder.verify(rankService, times(1)).createSellRank(any());
+    }
+
+    @DisplayName("최근 3일 가장 많이 팔린 상위 상품 5개를 조회한다.")
+    @Test
+    void getPopularProducts() {
+        // given
+        RankInfo.PopularProducts rankPopularProducts = RankInfo.PopularProducts.of(List.of(
+            RankInfo.PopularProduct.of(1L, 120L),  // 1등 상품
+            RankInfo.PopularProduct.of(2L, 95L),   // 2등 상품
+            RankInfo.PopularProduct.of(3L, 87L),   // 3등 상품
+            RankInfo.PopularProduct.of(4L, 76L),   // 4등 상품
+            RankInfo.PopularProduct.of(5L, 65L)   // 5등 상품
+        ));
+        when(rankService.getPopularSellRank(any()))
+            .thenReturn(rankPopularProducts);
+
+        ProductInfo.Products products = ProductInfo.Products.of(List.of(
+            ProductInfo.Product.builder()
+                .productId(1L)
+                .productName("상품명1")
+                .productPrice(1_000L)
+                .build(),
+            ProductInfo.Product.builder()
+                .productId(2L)
+                .productName("상품명2")
+                .productPrice(2_000L)
+                .build(),
+            ProductInfo.Product.builder()
+                .productId(3L)
+                .productName("상품명3")
+                .productPrice(3_000L)
+                .build(),
+            ProductInfo.Product.builder()
+                .productId(4L)
+                .productName("상품명4")
+                .productPrice(4_000L)
+                .build(),
+            ProductInfo.Product.builder()
+                .productId(5L)
+                .productName("상품명5")
+                .productPrice(5_000L)
+                .build()
+        ));
+
+        when(productService.getProducts(any()))
+            .thenReturn(products);
+
+        // when
+        RankResult.PopularProducts popularProducts = rankFacade.getPopularProducts(RankCriteria.PopularProducts.ofTop5Days3());
+
+        // then
+        InOrder inOrder = inOrder(rankService, productService);
+        inOrder.verify(rankService, times(1)).getPopularSellRank(any());
+        inOrder.verify(productService, times(1)).getProducts(any());
+
+        assertThat(popularProducts.getProducts()).hasSize(5)
+            .extracting("productId", "productName", "productPrice")
+            .containsExactly(
+                tuple(1L, "상품명1", 1_000L),
+                tuple(2L, "상품명2", 2_000L),
+                tuple(3L, "상품명3", 3_000L),
+                tuple(4L, "상품명4", 4_000L),
+                tuple(5L, "상품명5", 5_000L)
+            );
     }
 
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/docs/product/ProductControllerDocsTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/docs/product/ProductControllerDocsTest.java
@@ -61,37 +61,4 @@ class ProductControllerDocsTest extends RestDocsSupport {
                 )
             ));
     }
-
-    @DisplayName("상위 상품 Top5 목록 조회 API")
-    @Test
-    void getRanks() throws Exception {
-        // given
-        when(productFacade.getPopularProducts())
-            .thenReturn(ProductResult.Products.of(
-                List.of(
-                    ProductResult.Product.of(1L, "상품명", 300_000L, 3)
-                )
-            ));
-
-        // when & then
-        mockMvc.perform(
-                get("/api/v1/products/ranks")
-            )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andDo(document("get-ranks",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                responseFields(
-                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
-                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메세지"),
-                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
-                    fieldWithPath("data.products[]").type(JsonFieldType.ARRAY).description("상품 목록"),
-                    fieldWithPath("data.products[].id").type(JsonFieldType.NUMBER).description("상품 ID"),
-                    fieldWithPath("data.products[].name").type(JsonFieldType.STRING).description("상품 이름"),
-                    fieldWithPath("data.products[].price").type(JsonFieldType.NUMBER).description("가격"),
-                    fieldWithPath("data.products[].stock").type(JsonFieldType.NUMBER).description("재고 수")
-                )
-            ));
-    }
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/docs/rank/RankControllerDocsTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/docs/rank/RankControllerDocsTest.java
@@ -1,0 +1,64 @@
+package kr.hhplus.be.ecommerce.docs.rank;
+
+import kr.hhplus.be.ecommerce.application.rank.RankFacade;
+import kr.hhplus.be.ecommerce.application.rank.RankResult;
+import kr.hhplus.be.ecommerce.interfaces.rank.RankController;
+import kr.hhplus.be.ecommerce.support.RestDocsSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RankControllerDocsTest extends RestDocsSupport {
+
+    private final RankFacade rankFacade = mock(RankFacade.class);
+
+    @Override
+    protected Object initController() {
+        return new RankController(rankFacade);
+    }
+
+    @DisplayName("상위 상품 Top5 목록 조회 API")
+    @Test
+    void getRanks() throws Exception {
+        // given
+        when(rankFacade.getPopularProducts(any()))
+            .thenReturn(RankResult.PopularProducts.of(
+                List.of(
+                    RankResult.PopularProduct.of(1L, "상품명", 300_000L)
+                )
+            ));
+
+        // when & then
+        mockMvc.perform(
+                get("/api/v1/products/ranks")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(document("get-ranks",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.products[]").type(JsonFieldType.ARRAY).description("상품 목록"),
+                    fieldWithPath("data.products[].id").type(JsonFieldType.NUMBER).description("상품 ID"),
+                    fieldWithPath("data.products[].name").type(JsonFieldType.STRING).description("상품 이름"),
+                    fieldWithPath("data.products[].price").type(JsonFieldType.NUMBER).description("가격")
+                )
+            ));
+    }
+}

--- a/src/test/java/kr/hhplus/be/ecommerce/interfaces/product/ProductControllerE2ETest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/interfaces/product/ProductControllerE2ETest.java
@@ -3,8 +3,6 @@ package kr.hhplus.be.ecommerce.interfaces.product;
 import kr.hhplus.be.ecommerce.domain.product.Product;
 import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
 import kr.hhplus.be.ecommerce.domain.product.ProductSellingStatus;
-import kr.hhplus.be.ecommerce.domain.rank.Rank;
-import kr.hhplus.be.ecommerce.domain.rank.RankRepository;
 import kr.hhplus.be.ecommerce.domain.stock.Stock;
 import kr.hhplus.be.ecommerce.domain.stock.StockRepository;
 import kr.hhplus.be.ecommerce.support.E2EControllerTestSupport;
@@ -12,9 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-
-import java.time.LocalDate;
-import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -26,9 +21,6 @@ class ProductControllerE2ETest extends E2EControllerTestSupport {
 
     @Autowired
     private StockRepository stockRepository;
-
-    @Autowired
-    private RankRepository rankRepository;
 
     @DisplayName("상품 목록을 가져온다.")
     @Test
@@ -61,61 +53,5 @@ class ProductControllerE2ETest extends E2EControllerTestSupport {
             .body("data.products[1].name", equalTo(product2.getName()))
             .body("data.products[1].price", equalTo(200_000))
             .body("data.products[1].stock", equalTo(stock2.getQuantity()));
-    }
-
-    @DisplayName("상위 상품 Top5 목록을 가져온다.")
-    @Test
-    void getRanks() {
-        // given
-        Product product1 = Product.create("항해 블랙뱃지", 100_000L, ProductSellingStatus.SELLING);
-        Product product2 = Product.create("항해 화이트뱃지", 200_000L, ProductSellingStatus.SELLING);
-        Product product3 = Product.create("항해 블루뱃지", 300_000L, ProductSellingStatus.SELLING);
-        Product product4 = Product.create("항해 레드뱃지", 400_000L, ProductSellingStatus.SELLING);
-        Product product5 = Product.create("항해 그린뱃지", 500_000L, ProductSellingStatus.SELLING);
-        List.of(product1, product2, product3, product4, product5).forEach(productRepository::save);
-
-        Stock stock1 = Stock.create(product1.getId(), 1);
-        Stock stock2 = Stock.create(product2.getId(), 2);
-        Stock stock3 = Stock.create(product3.getId(), 3);
-        Stock stock4 = Stock.create(product4.getId(), 4);
-        Stock stock5 = Stock.create(product5.getId(), 5);
-        List.of(stock1, stock2, stock3, stock4, stock5).forEach(stockRepository::save);
-
-        Rank rank1 = Rank.createSell(product1.getId(), LocalDate.now().minusDays(3), 10);
-        Rank rank2 = Rank.createSell(product2.getId(), LocalDate.now().minusDays(2), 20);
-        Rank rank3 = Rank.createSell(product3.getId(), LocalDate.now().minusDays(1), 30);
-        Rank rank4 = Rank.createSell(product4.getId(), LocalDate.now().minusDays(1), 40);
-        Rank rank5 = Rank.createSell(product5.getId(), LocalDate.now().minusDays(1), 50);
-        List.of(rank1, rank2, rank3, rank4, rank5).forEach(rankRepository::save);
-
-        // when & then
-        given()
-        .when()
-            .get("/api/v1/products/ranks")
-        .then()
-            .log().all()
-            .statusCode(HttpStatus.OK.value())
-            .body("code", equalTo(200))
-            .body("message", equalTo("OK"))
-            .body("data.products[0].id", equalTo(product5.getId().intValue()))
-            .body("data.products[0].name", equalTo(product5.getName()))
-            .body("data.products[0].price", equalTo(500_000))
-            .body("data.products[0].stock", equalTo(stock5.getQuantity()))
-            .body("data.products[1].id", equalTo(product4.getId().intValue()))
-            .body("data.products[1].name", equalTo(product4.getName()))
-            .body("data.products[1].price", equalTo(400_000))
-            .body("data.products[1].stock", equalTo(stock4.getQuantity()))
-            .body("data.products[2].id", equalTo(product3.getId().intValue()))
-            .body("data.products[2].name", equalTo(product3.getName()))
-            .body("data.products[2].price", equalTo(300_000))
-            .body("data.products[2].stock", equalTo(stock3.getQuantity()))
-            .body("data.products[3].id", equalTo(product2.getId().intValue()))
-            .body("data.products[3].name", equalTo(product2.getName()))
-            .body("data.products[3].price", equalTo(200_000))
-            .body("data.products[3].stock", equalTo(stock2.getQuantity()))
-            .body("data.products[4].id", equalTo(product1.getId().intValue()))
-            .body("data.products[4].name", equalTo(product1.getName()))
-            .body("data.products[4].price", equalTo(100_000))
-            .body("data.products[4].stock", equalTo(stock1.getQuantity()));
     }
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/interfaces/product/ProductControllerTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/interfaces/product/ProductControllerTest.java
@@ -39,29 +39,4 @@ class ProductControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.data.products[*].price").value(300000))
             .andExpect(jsonPath("$.data.products[*].stock").value(3));
     }
-
-    @DisplayName("상위 상품 Top5 목록을 가져온다.")
-    @Test
-    void getRanks() throws Exception {
-        // given
-        when(productFacade.getPopularProducts())
-            .thenReturn(ProductResult.Products.of(
-                List.of(
-                    ProductResult.Product.of(1L, "상품명", 300_000L, 3)
-                )
-            ));
-
-        // when & then
-        mockMvc.perform(
-                get("/api/v1/products/ranks")
-            )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.code").value(200))
-            .andExpect(jsonPath("$.message").value("OK"))
-            .andExpect(jsonPath("$.data.products[*].id").value(1))
-            .andExpect(jsonPath("$.data.products[*].name").value("상품명"))
-            .andExpect(jsonPath("$.data.products[*].price").value(300000))
-            .andExpect(jsonPath("$.data.products[*].stock").value(3));
-    }
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/interfaces/rank/RankControllerE2ETest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/interfaces/rank/RankControllerE2ETest.java
@@ -1,0 +1,71 @@
+package kr.hhplus.be.ecommerce.interfaces.rank;
+
+import kr.hhplus.be.ecommerce.domain.product.Product;
+import kr.hhplus.be.ecommerce.domain.product.ProductRepository;
+import kr.hhplus.be.ecommerce.domain.product.ProductSellingStatus;
+import kr.hhplus.be.ecommerce.domain.rank.Rank;
+import kr.hhplus.be.ecommerce.domain.rank.RankRepository;
+import kr.hhplus.be.ecommerce.support.E2EControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+class RankControllerE2ETest extends E2EControllerTestSupport {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private RankRepository rankRepository;
+
+    @DisplayName("상위 상품 Top5 목록을 가져온다.")
+    @Test
+    void getRanks() {
+        // given
+        Product product1 = Product.create("항해 블랙뱃지", 100_000L, ProductSellingStatus.SELLING);
+        Product product2 = Product.create("항해 화이트뱃지", 200_000L, ProductSellingStatus.SELLING);
+        Product product3 = Product.create("항해 블루뱃지", 300_000L, ProductSellingStatus.SELLING);
+        Product product4 = Product.create("항해 레드뱃지", 400_000L, ProductSellingStatus.SELLING);
+        Product product5 = Product.create("항해 그린뱃지", 500_000L, ProductSellingStatus.SELLING);
+        List.of(product1, product2, product3, product4, product5).forEach(productRepository::save);
+
+        Rank rank1 = Rank.createSell(product1.getId(), LocalDate.now().minusDays(3), 10);
+        Rank rank2 = Rank.createSell(product2.getId(), LocalDate.now().minusDays(2), 20);
+        Rank rank3 = Rank.createSell(product3.getId(), LocalDate.now().minusDays(1), 30);
+        Rank rank4 = Rank.createSell(product4.getId(), LocalDate.now().minusDays(1), 40);
+        Rank rank5 = Rank.createSell(product5.getId(), LocalDate.now().minusDays(1), 50);
+        List.of(rank1, rank2, rank3, rank4, rank5).forEach(rankRepository::save);
+
+        // when & then
+        given()
+        .when()
+            .get("/api/v1/products/ranks")
+        .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(200))
+            .body("message", equalTo("OK"))
+            .body("data.products[0].id", equalTo(product5.getId().intValue()))
+            .body("data.products[0].name", equalTo(product5.getName()))
+            .body("data.products[0].price", equalTo(500_000))
+            .body("data.products[1].id", equalTo(product4.getId().intValue()))
+            .body("data.products[1].name", equalTo(product4.getName()))
+            .body("data.products[1].price", equalTo(400_000))
+            .body("data.products[2].id", equalTo(product3.getId().intValue()))
+            .body("data.products[2].name", equalTo(product3.getName()))
+            .body("data.products[2].price", equalTo(300_000))
+            .body("data.products[3].id", equalTo(product2.getId().intValue()))
+            .body("data.products[3].name", equalTo(product2.getName()))
+            .body("data.products[3].price", equalTo(200_000))
+            .body("data.products[4].id", equalTo(product1.getId().intValue()))
+            .body("data.products[4].name", equalTo(product1.getName()))
+            .body("data.products[4].price", equalTo(100_000));
+    }
+}

--- a/src/test/java/kr/hhplus/be/ecommerce/interfaces/rank/RankControllerTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/interfaces/rank/RankControllerTest.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.ecommerce.interfaces.rank;
+
+import kr.hhplus.be.ecommerce.application.rank.RankResult;
+import kr.hhplus.be.ecommerce.support.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RankControllerTest extends ControllerTestSupport {
+
+    @DisplayName("상위 상품 Top5 목록을 가져온다.")
+    @Test
+    void getRanks() throws Exception {
+        // given
+        when(rankFacade.getPopularProducts(any()))
+            .thenReturn(RankResult.PopularProducts.of(
+                List.of(
+                    RankResult.PopularProduct.of(1L, "상품명", 300_000L)
+                )
+            ));
+
+        // when & then
+        mockMvc.perform(
+                get("/api/v1/products/ranks")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data.products[*].id").value(1))
+            .andExpect(jsonPath("$.data.products[*].name").value("상품명"))
+            .andExpect(jsonPath("$.data.products[*].price").value(300000));
+    }
+}

--- a/src/test/java/kr/hhplus/be/ecommerce/support/ControllerTestSupport.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/support/ControllerTestSupport.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.hhplus.be.ecommerce.application.balance.BalanceFacade;
 import kr.hhplus.be.ecommerce.application.order.OrderFacade;
 import kr.hhplus.be.ecommerce.application.product.ProductFacade;
+import kr.hhplus.be.ecommerce.application.rank.RankFacade;
 import kr.hhplus.be.ecommerce.application.user.UserCouponFacade;
 import kr.hhplus.be.ecommerce.interfaces.balance.BalanceController;
 import kr.hhplus.be.ecommerce.interfaces.order.OrderController;
 import kr.hhplus.be.ecommerce.interfaces.product.ProductController;
+import kr.hhplus.be.ecommerce.interfaces.rank.RankController;
 import kr.hhplus.be.ecommerce.interfaces.user.UserCouponController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
     UserCouponController.class,
     OrderController.class,
     ProductController.class,
+    RankController.class,
 })
 public abstract class ControllerTestSupport {
 
@@ -36,6 +39,9 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected ProductFacade productFacade;
+
+    @MockitoBean
+    protected RankFacade rankFacade;
 
     @MockitoBean
     protected UserCouponFacade userCouponFacade;

--- a/src/test/java/kr/hhplus/be/ecommerce/support/E2EControllerTestSupport.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/support/E2EControllerTestSupport.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.ecommerce.support;
 
 import io.restassured.RestAssured;
 import kr.hhplus.be.ecommerce.support.database.DatabaseCleaner;
+import kr.hhplus.be.ecommerce.support.database.RedisCacheCleaner;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,9 @@ public abstract class E2EControllerTestSupport extends IntegrationTestSupport {
     @Autowired
     private DatabaseCleaner databaseCleaner;
 
+    @Autowired
+    private RedisCacheCleaner redisCacheCleaner;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
@@ -23,5 +27,6 @@ public abstract class E2EControllerTestSupport extends IntegrationTestSupport {
     @AfterEach
     void tearDown() {
         databaseCleaner.clean();
+        redisCacheCleaner.clean();
     }
 }

--- a/src/test/java/kr/hhplus/be/ecommerce/support/database/RedisCacheCleaner.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/support/database/RedisCacheCleaner.java
@@ -1,0 +1,45 @@
+package kr.hhplus.be.ecommerce.support.database;
+
+import kr.hhplus.be.ecommerce.support.cache.CacheType;
+import kr.hhplus.be.ecommerce.support.cache.Cacheable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Arrays;
+import java.util.Set;
+
+@Component
+@Profile("test")
+public class RedisCacheCleaner {
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    public void clean() {
+        Arrays.stream(CacheType.values())
+            .map(Cacheable::cacheName)
+            .map(this::getKeys)
+            .filter(this::isExistKeys)
+            .forEach(this::cleanBy);
+    }
+
+    private Set<String> getKeys(String name) {
+        String keyPattern = getKeyPattern(name);
+        return stringRedisTemplate.keys(keyPattern);
+    }
+
+    private String getKeyPattern(String name) {
+        return name + "*";
+    }
+
+    private boolean isExistKeys(Set<String> keys) {
+        return !CollectionUtils.isEmpty(keys);
+    }
+
+    private Long cleanBy(Set<String> keys) {
+        return stringRedisTemplate.delete(keys);
+    }
+}

--- a/src/test/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilterIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilterIntegrationTest.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.ecommerce.support.filter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(LoggingFilterIntegrationTest.DummyController.class)
+class LoggingFilterIntegrationTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @DisplayName("로깅 필터가 정상적으로 동작한다.")
+    @Test
+    void doFilterInternal() throws Exception {
+        // when
+        MvcResult result = mockMvc.perform(
+            post("/api/test")
+                .content("sample")
+                .contentType(MediaType.TEXT_PLAIN)
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andReturn();
+
+        // then
+        String traceId = result.getResponse().getHeader("X-Trace-Id");
+        assertThat(traceId).isNotBlank();
+    }
+
+    @DisplayName("예외가 발생해도 로깅 필터가 정상적으로 동작한다.")
+    @Test
+    void doFilterInternalWithException() throws Exception {
+        // when
+        MvcResult result = mockMvc.perform(
+                post("/api/test/exception")
+                    .content("sample")
+                    .contentType(MediaType.TEXT_PLAIN)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        // then
+        String traceId = result.getResponse().getHeader("X-Trace-Id");
+        assertThat(traceId).isNotBlank();
+    }
+
+    @RestController
+    static class DummyController {
+        @PostMapping("/api/test")
+        public ResponseEntity<String> test(@RequestBody String body) {
+            return ResponseEntity.ok("response-body");
+        }
+
+        @PostMapping("/api/test/exception")
+        public ResponseEntity<String> testException(@RequestBody String body) {
+            throw new IllegalArgumentException("test exception");
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilterUnitTest.java
+++ b/src/test/java/kr/hhplus/be/ecommerce/support/filter/LoggingFilterUnitTest.java
@@ -1,0 +1,44 @@
+package kr.hhplus.be.ecommerce.support.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import kr.hhplus.be.ecommerce.support.MockTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoggingFilterUnitTest extends MockTestSupport {
+
+    @InjectMocks
+    private LoggingFilter loggingFilter;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @DisplayName("로깅 필터가 정상적으로 동작한다.")
+    @Test
+    void doFilterInternal() throws ServletException, IOException {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+        // when
+        loggingFilter.doFilterInternal(requestWrapper, responseWrapper, filterChain);
+
+        // then
+        String traceId = response.getHeader("X-Trace-Id");
+        assertThat(traceId).isNotNull();
+    }
+}


### PR DESCRIPTION
### #️⃣ **이슈번호**

+ #31 
+ #32 
+ #35 

---
### **🔗 커밋 링크**

+ Redis 캐시 관련 클래스 작성 : [9009570](https://github.com/discphy/hhplus-e-commerce/pull/34/commits/9009570d25d73cdee52dbfdfe2042cbda2d5d875)
+ Redis 캐시 클렌징 코드 작성 : [b6869b2](https://github.com/discphy/hhplus-e-commerce/pull/34/commits/b6869b2209aac3323b4c074a21bbbf96887af847)
+ Redis 인기상품 조회 캐시 작성 : [cf10b37](https://github.com/discphy/hhplus-e-commerce/pull/34/commits/cf10b377a09fc7e9c0892735cf624276848c9432)
+ 캐싱 전략 및 성능 보고서 작성 : [b77c6f5](https://github.com/discphy/hhplus-e-commerce/pull/34/commits/b77c6f5510faf82e2b07cc60a649151544bf5e72)
+ 로킹 필터 수정 및 단위/통합테스트 작성 : [129c4ae](https://github.com/discphy/hhplus-e-commerce/pull/34/commits/129c4ae059c2450443c5a58b5055509e5de51c77)

보고서 링크 바로가기 👉 [캐시 전략 및 성능 보고서](https://github.com/discphy/hhplus-e-commerce/blob/week6/2/docs/report/03.CacheStrategyArchitectureReport.md)

---
### 💭 **리뷰 포인트(질문)**

+ 실무에서는 `@Cacheable` 어노테이션을 주로 사용해서 캐싱을 구현하시나요? 아니면 `RedisTemplate`을 활용해 캐시를 직접 제어하시는 방식도 자주 사용하시나요? 구현 방식이 궁금합니다!

+ 지난 번에 “주문서”는 DB가 아닌 Redis에 저장하는 방식으로 많이 사용한다고 말씀해주신 걸로 기억합니다.

   그런데 “장바구니” 역시 주문서처럼 일시적인 데이터로 보이는데요,
   실무에서는 장바구니도 동일하게 Redis에 저장해서 관리하시나요?

   혹시 장바구니는 별도로 DB에 저장해야 하는 다른 이유가 있을지 궁금합니다.

---
### 📝 **이번주 KPT 회고**

✅ Keep
<!-- 유지해야 할 좋은 점 -->
추가로 리팩토링 해야될 부분에 대해 Issue에 등록하고 리팩토링을 진행할 예정입니다.

+ [X] LoggingFilter 수정 
+ [X] Filter 단위 테스트, 통합 테스트 코드 작성 
+ [x] AOP 통합 테스트 코드 작성
+ [ ] Caffeine 로컬 캐시 레이어 적용 
+ [ ] Facade 예외 케이스 테스트 코드 작성 
+ [ ] 상품 조회 커서 기반 페이징 적용
+ [ ] 상품 조회 캐싱 적용
+ [ ] 상품 상세 조회 API 추가
+ [ ] 상품 상세 PDP 캐싱 적용

❌ Problem
<!--개선이 필요한 점-->
WIL 작성이 계속 밀리고 있는데 틈틈히 작성해야 될 것 같습니다.. 

🔁 Try
<!-- 새롭게 시도할 점 -->
주차를 거듭할수록 과제의 난이도가 올라가므로, 더 많은 시간 투자를 하여 깊은 개념적 이해가 필요해보입니다.
 